### PR TITLE
Revert "package: Expand "*" to empty if it matches CC"

### DIFF
--- a/nattka/__main__.py
+++ b/nattka/__main__.py
@@ -713,8 +713,7 @@ class NattkaCommands(object):
                     if (('*' in b.atoms or '^' in b.atoms)
                             and (arches_cced or cc_arches)):
                         try:
-                            expanded_plist = expand_package_list(
-                                repo, b, cc_arches or b.cc)
+                            expanded_plist = expand_package_list(repo, b)
                         except ExpandImpossible:
                             pass
 

--- a/nattka/package.py
+++ b/nattka/package.py
@@ -376,21 +376,18 @@ def match_package_list(repo: UnconfiguredTree,
 
 def expand_package_list(repo: UnconfiguredTree,
                         bug: BugInfo,
-                        target_cc: typing.Iterable[str],
                         ) -> str:
     """
     Expand `*` and `^` entries in package list
 
     `repo` is the repository, `bug` is the original bug to work on.
-    `target_cc` specifies expected CC list (to simplify "*").  Returns
-    new package list contents.
+    Returns new package list contents.
 
     Note that this function assumes that match_package_list() has been
     called already, and did not raise any exceptions, i.e. that the bug
     is known to have a valid package list.
     """
 
-    target_cc = frozenset(target_cc)
     ret = ''
     prev_kw = None
     for line in bug.atoms.splitlines(keepends=True):
@@ -418,13 +415,9 @@ def expand_package_list(repo: UnconfiguredTree,
                 pkg = select_best_version(m)
                 cur_kw = []
             elif w == '*':
-                assert target_cc
                 match_keywords = get_suggested_keywords(
                     repo, pkg, bug.category == BugCategory.STABLEREQ)
-                if target_cc == set(f'{x}@gentoo.org'
-                                    for x in match_keywords):
-                    w = ''
-                elif match_keywords:
+                if match_keywords:
                     w = ' '.join(
                         sorted(match_keywords, key=keyword_sort_key))
                 else:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1588,8 +1588,8 @@ class IntegrationSuccessTests(IntegrationTestCase):
         bugz_inst.update_status.assert_called_with(
             560322, True, None,
             cc_add=['amd64@gentoo.org', 'hppa@gentoo.org', 'foo@example.com'],
-            new_package_list=['test/mixed-keywords-3 \r\n'
-                              'test/amd64-testing-2 \r\n'])
+            new_package_list=['test/mixed-keywords-3 amd64 hppa\r\n'
+                              'test/amd64-testing-2 amd64 hppa\r\n'])
         self.post_verify()
 
     @patch('nattka.__main__.NattkaBugzilla')
@@ -1633,8 +1633,8 @@ class IntegrationSuccessTests(IntegrationTestCase):
         bugz_inst.find_bugs.assert_called_with(bugs=[560322])
         bugz_inst.update_status.assert_called_with(
             560322, True, None,
-            new_package_list=['test/mixed-keywords-3 \r\n'
-                              'test/amd64-testing-2 \r\n'])
+            new_package_list=['test/mixed-keywords-3 amd64 hppa\r\n'
+                              'test/amd64-testing-2 amd64 hppa\r\n'])
         self.post_verify()
 
     @patch('nattka.__main__.NattkaBugzilla')

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -819,8 +819,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         self.assertEqual(
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['amd64@gentoo.org', 'hppa@gentoo.org']),
+                                BugInfo(BugCategory.STABLEREQ, data)),
             data)
 
     def test_asterisk_streq(self):
@@ -836,8 +835,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         self.assertEqual(
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['hppa@gentoo.org']),
+                                BugInfo(BugCategory.STABLEREQ, data)),
             expect)
 
     def test_asterisk_kwreq(self):
@@ -853,25 +851,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         self.assertEqual(
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.KEYWORDREQ, data),
-                                ['hppa@gentoo.org']),
-            expect)
-
-    def test_asterisk_to_empty(self):
-        data = '''
-            test/mixed-keywords-3    *
-            test/mixed-keywords-4    ^
-            test/amd64-testing-1     ^
-        '''
-        expect = f'''
-            test/mixed-keywords-3    {""}
-            test/mixed-keywords-4    {""}
-            test/amd64-testing-1     {""}
-        '''
-        self.assertEqual(
-            expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['amd64@gentoo.org', 'hppa@gentoo.org']),
+                                BugInfo(BugCategory.KEYWORDREQ, data)),
             expect)
 
     def test_above(self):
@@ -891,8 +871,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         self.assertEqual(
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['hppa@gentoo.org']),
+                                BugInfo(BugCategory.STABLEREQ, data)),
             expect)
 
     def test_above_empty(self):
@@ -906,8 +885,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         self.assertEqual(
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['hppa@gentoo.org']),
+                                BugInfo(BugCategory.STABLEREQ, data)),
             expect)
 
     def test_above_empty_plus_keywords_left(self):
@@ -917,8 +895,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         with self.assertRaises(ExpandImpossible):
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['hppa@gentoo.org'])
+                                BugInfo(BugCategory.STABLEREQ, data))
 
     def test_above_empty_plus_keywords_right(self):
         data = '''
@@ -927,8 +904,7 @@ class ExpandPackageListTests(BaseRepoTestCase):
         '''
         with self.assertRaises(ExpandImpossible):
             expand_package_list(self.repo,
-                                BugInfo(BugCategory.STABLEREQ, data),
-                                ['hppa@gentoo.org'])
+                                BugInfo(BugCategory.STABLEREQ, data))
 
 
 class FakeEbuild(object):


### PR DESCRIPTION
Revert "package: Expand "*" to empty if it matches CC"

This reverts commit 2e079dd3463f2d5ad8005d42a3e83e094aaa9325.

Given a package list containing `=category/package-${PV}*`, nattka will
remove the `*` and not replace it with a list of architecture keywords
iff the set of architectures to be CC'd matches the set of stable
keywords for `=category/package-${PV}`.

This behavior was added in commit 2e079dd ("package: Expand "*" to empty
if it matches CC") to allow reusing a stabilization bug for an
additional architecture by only adding the new architecture to the CC
list.

This has the unfortunate side-effect of making a nattka-processed
package list unacceptable to nattka itself if the package list needs to
be modified. See https://bugs.gentoo.org/920053#c18 for example.

Revert to the original behavior of always expanding `*` to the
architecture list. If a stabilization needs to happen on an additional
architecture, the additional architecture keyword should be added to the
package list so nattka can sanity-check it.

Signed-off-by: Matt Turner <mattst88@gentoo.org>

Related: https://github.com/mgorny/nattka/issues/36